### PR TITLE
Suggestion of a small example about the connection to upstream error

### DIFF
--- a/sites/connection-to-upstream.en.md
+++ b/sites/connection-to-upstream.en.md
@@ -71,6 +71,8 @@ ModuleNotFoundError: No module named 'XXXX'
 
 Depending on the error, correct the site, the virtual environment or the script itself.
 
+For instance, for a Python application (such as Django), check that the version in your virtual environment matches the version declared in your site (in the admin interface).
+
 ## Other HTTP servers
 
 For sites that do not use Apache or uWSGI, check the program run in [SSH]({{< ref "remote-access/ssh" >}}). Especially whether it does properly listen on:

--- a/sites/connection-to-upstream.fr.md
+++ b/sites/connection-to-upstream.fr.md
@@ -69,6 +69,8 @@ ModuleNotFoundError: No module named 'XXXX'
 
 Selon l'erreur corrigez le site, l'environnement virtuel ou encore le script lui-même.
 
+Par exemple, pour une application Python (tel que Django), vérifiez que la version dans l'environnement virtuel correspond à la version déclarée dans le site (de l'interface d'administration).
+
 ## Autres serveurs HTTP
 
 Pour les sites ne passant pas par Apache ou uWSGI, vérifiez le lancement du programme en [SSH]({{< ref "remote-access/ssh" >}}). Notamment s'il écoute bien :


### PR DESCRIPTION
Hi,

This a suggestion of a small example about the "connection to upstream" error. Error I encountered after upgrading a Django website to a python venv with a newer version of Python, while I at the same time I forgot to update my "site".

In case it can help somebody else.
