### PR TITLE
Enhance readability of MongoDB section

### DIFF
--- a/content/guides/mongodb.en.md
+++ b/content/guides/mongodb.en.md
@@ -5,7 +5,7 @@ hidden = true
 tags = ["databases", "mongodb"]
 +++
 
- [MongoDB](https://www.mongodb.com/) is a document-oriented noSQL database program. 
+[MongoDB](https://www.mongodb.com/) is a document-oriented noSQL database program.
 
 In our example, we use the [SSH access]({{< ref "remote-access/ssh">}}) and consider the following information:
 
@@ -17,6 +17,7 @@ In our example, we use the [SSH access]({{< ref "remote-access/ssh">}}) and cons
 {{% /notice %}}
 
 ## Installation
+
 ### Downloading
 
 ```sh
@@ -40,7 +41,7 @@ Create a [service]({{< ref "services" >}}) with following details:
 The address to connect to the MongoDB instance will be `services-[foo].alwaysdata.net:[port]`.
 
 {{% notice note %}}
-Remplace `[port]` by the chosen port in the command.
+Replace `[port]` by the chosen port in the command.
 {{% /notice %}}
 
 ### Firewall rule creation
@@ -60,7 +61,7 @@ Remplace `[port]` by the chosen port in the command.
 
 - [mongosh](https://www.mongodb.com/try/download/shell) - choose the package *tgz* and the platform *Linux x64* of the last version.
 
-```
+```sh
 foo@ssh:~/mongodb$ wget -O- https://downloads.mongodb.com/compass/mongosh-2.3.2-linux-x64.tgz | tar -xz --strip-components=0
 foo@ssh:~/mongodb$ mv mongosh-2.3.2-linux-x64/bin/* bin/
 foo@ssh:~/mongodb$ rm -rf mongosh-2.3.2-linux-x64
@@ -68,7 +69,7 @@ foo@ssh:~/mongodb$ rm -rf mongosh-2.3.2-linux-x64
 
 - [cli](https://www.mongodb.com/try/download/database-tools) - choose the package *tgz* and the platform *Debian 12.0 x86-64* of the last version.
 
-```
+```sh
 foo@ssh:~/mongodb$ wget -O- https://fastdl.mongodb.org/tools/db/mongodb-database-tools-debian12-x86_64-100.10.0.tgz | tar -xz --strip-components=0
 foo@ssh:~/mongodb$ mv mongodb-database-tools-debian12-x86_64-100.10.0/bin/* bin/
 foo@ssh:~/mongodb$ rm -rf mongodb-database-tools-debian12-x86_64-100.10.0

--- a/content/guides/mongodb.fr.md
+++ b/content/guides/mongodb.fr.md
@@ -18,6 +18,7 @@ Dans notre exemple, nous utilisons un [accès SSH]({{< ref "remote-access/ssh">}
 {{% /notice %}}
 
 ## Installation
+
 ### Téléchargement
 
 ```sh
@@ -61,7 +62,7 @@ Les utilisateurs du [Cloud Privé]({{< ref "accounts/billing/private-cloud-price
 
 - [mongosh](https://www.mongodb.com/try/download/shell) - choisissez le paquet *tgz* et la plateforme *Linux x64* de la dernière version.
 
-```
+```sh
 foo@ssh:~/mongodb$ wget -O- https://downloads.mongodb.com/compass/mongosh-2.3.2-linux-x64.tgz | tar -xz --strip-components=0
 foo@ssh:~/mongodb$ mv mongosh-2.3.2-linux-x64/bin/* bin/
 foo@ssh:~/mongodb$ rm -rf mongosh-2.3.2-linux-x64
@@ -69,7 +70,7 @@ foo@ssh:~/mongodb$ rm -rf mongosh-2.3.2-linux-x64
 
 - [cli](https://www.mongodb.com/try/download/database-tools) - choisissez le paquet *tgz* et la plateforme *Debian 12.0 x86-64* de la dernière version.
 
-```
+```sh
 foo@ssh:~/mongodb$ wget -O- https://fastdl.mongodb.org/tools/db/mongodb-database-tools-debian12-x86_64-100.10.0.tgz | tar -xz --strip-components=0
 foo@ssh:~/mongodb$ mv mongodb-database-tools-debian12-x86_64-100.10.0/bin/* bin/
 foo@ssh:~/mongodb$ rm -rf mongodb-database-tools-debian12-x86_64-100.10.0


### PR DESCRIPTION
I fixed a few things to enhance the readability of the MongoDB section.

While trying to install mongodb from the tar file as documented I faced the issue that the **OpenSSL shared libraries** are apparently **not** included and therefore need to be obtained separately.
After building OpenSSL 3 from source (and including in `LD_LIBRARY_PATH`) I received several errors concerning the glib version:

```bash
/home/USERNAME/mongodb/bin/mongod: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found (required by /home/USERNAME/mongodb/bin/mongod)
/home/USERNAME/mongodb/bin/mongod: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /home/USERNAME/mongodb/bin/mongod)
/home/USERNAME/mongodb/bin/mongod: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /home/USERNAME/mongodb/bin/mongod)
/home/USERNAME/mongodb/bin/mongod: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /home/USERNAME/mongodb/bin/mongod)
```

list of required shared libraries (generated using `ldd`):

```bash
LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/USERNAME/mongodb/bin ldd /home/USERNAME/mongodb/bin/mongod
	linux-vdso.so.1 (0x00007ffc39fe9000)
	libcurl.so.4 => /lib/x86_64-linux-gnu/libcurl.so.4 (0x00007f336a2e5000)
	libresolv.so.2 => /lib/x86_64-linux-gnu/libresolv.so.2 (0x00007f336a2cb000)
	libcrypto.so.3 => /home/USERNAME/mongodb/bin/libcrypto.so.3 (0x00007f3369d41000)
	libssl.so.3 => /home/USERNAME/mongodb/bin/libssl.so.3 (0x00007f3369c40000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f3369abd000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f3369aa3000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f33698e1000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f33742d9000)
	libnghttp2.so.14 => /lib/x86_64-linux-gnu/libnghttp2.so.14 (0x00007f33698b7000)
	libidn2.so.0 => /lib/x86_64-linux-gnu/libidn2.so.0 (0x00007f3369898000)
	librtmp.so.1 => /lib/x86_64-linux-gnu/librtmp.so.1 (0x00007f3369600000)
	libssh2.so.1 => /lib/x86_64-linux-gnu/libssh2.so.1 (0x00007f3369869000)
	libpsl.so.5 => /lib/x86_64-linux-gnu/libpsl.so.5 (0x00007f3369856000)
	libssl.so.1.1 => /lib/x86_64-linux-gnu/libssl.so.1.1 (0x00007f336956d000)
	libcrypto.so.1.1 => /lib/x86_64-linux-gnu/libcrypto.so.1.1 (0x00007f3369200000)
	libgssapi_krb5.so.2 => /lib/x86_64-linux-gnu/libgssapi_krb5.so.2 (0x00007f3369520000)
	libkrb5.so.3 => /lib/x86_64-linux-gnu/libkrb5.so.3 (0x00007f3369120000)
	libk5crypto.so.3 => /lib/x86_64-linux-gnu/libk5crypto.so.3 (0x00007f3369820000)
	libcom_err.so.2 => /lib/x86_64-linux-gnu/libcom_err.so.2 (0x00007f336951a000)
	libldap_r-2.4.so.2 => /lib/x86_64-linux-gnu/libldap_r-2.4.so.2 (0x00007f33690cc000)
	liblber-2.4.so.2 => /lib/x86_64-linux-gnu/liblber-2.4.so.2 (0x00007f3369509000)
	libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007f33690ae000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f336908d000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f3369504000)
	libunistring.so.2 => /lib/x86_64-linux-gnu/libunistring.so.2 (0x00007f3368f09000)
	libgnutls.so.30 => /lib/x86_64-linux-gnu/libgnutls.so.30 (0x00007f3368d5d000)
	libhogweed.so.4 => /lib/x86_64-linux-gnu/libhogweed.so.4 (0x00007f3368d24000)
	libnettle.so.6 => /lib/x86_64-linux-gnu/libnettle.so.6 (0x00007f3368cec000)
	libgmp.so.10 => /lib/x86_64-linux-gnu/libgmp.so.10 (0x00007f3368c69000)
	libgcrypt.so.20 => /lib/x86_64-linux-gnu/libgcrypt.so.20 (0x00007f3368b4b000)
	libkrb5support.so.0 => /lib/x86_64-linux-gnu/libkrb5support.so.0 (0x00007f33694f1000)
	libkeyutils.so.1 => /lib/x86_64-linux-gnu/libkeyutils.so.1 (0x00007f3368b44000)
	libsasl2.so.2 => /lib/x86_64-linux-gnu/libsasl2.so.2 (0x00007f3368b27000)
	libp11-kit.so.0 => /lib/x86_64-linux-gnu/libp11-kit.so.0 (0x00007f33689f8000)
	libtasn1.so.6 => /lib/x86_64-linux-gnu/libtasn1.so.6 (0x00007f33689e4000)
	libgpg-error.so.0 => /lib/x86_64-linux-gnu/libgpg-error.so.0 (0x00007f33689c1000)
	libffi.so.6 => /lib/x86_64-linux-gnu/libffi.so.6 (0x00007f33689b7000)
```

I'd be very grateful if you could provide some insights on these questions:

* which OpenSSL version should be used?
* Is there an alternative to building OpenSSL from source (takes ca. 5 to 10min)?
* Concerning the glib version issue: Several different versions are requested by `mongod`. Any insights on this rather weird situation would be highly appreciated.

It would be a lot easier if the Debian 10 installation had already OpenSSL 3 installed by default.

